### PR TITLE
Fix requests hanging when 'collect_statistics' is false or absence

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,14 +45,18 @@ func main() {
 		panic(err)
 	}
 
-	statisticsChannel := make(chan statistics.Request)
-	statisticsCollector := statistics.Collector{Chan: statisticsChannel}
-
 	var wg sync.WaitGroup
+	var statisticsChannel chan statistics.Request
+
 	if serverCollection.CollectStatistics {
 		wg.Add(1)
+
+		statisticsChannel = make(chan statistics.Request)
+
+		statisticsCollector := statistics.Collector{Chan: statisticsChannel}
 		go statisticsCollector.Run(&wg)
 	}
+
 	for _, server := range serverCollection.Servers {
 		wg.Add(1)
 		go server.Serve(statisticsChannel, &wg)

--- a/mock_server/endpoint/endpoint.go
+++ b/mock_server/endpoint/endpoint.go
@@ -1,6 +1,7 @@
 package endpoint
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/pokidovea/mimicro/mock_server/response"
@@ -52,6 +53,8 @@ func (endpoint Endpoint) GetHandler() func(w http.ResponseWriter, req *http.Requ
 			statisticsRequest.StatusCode = http.StatusNotFound
 			http.NotFound(w, req)
 		}
+		log.Printf("Requested %s \n", statisticsRequest)
+
 		if endpoint.statisticsChannel != nil {
 			endpoint.statisticsChannel <- statisticsRequest
 		}

--- a/statistics/statistics.go
+++ b/statistics/statistics.go
@@ -1,6 +1,7 @@
 package statistics
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -14,6 +15,16 @@ type Request struct {
 	StatusCode int    `json:"status_code"`
 }
 
+func (request Request) String() string {
+	return fmt.Sprintf(
+		"server: %s; url: %s; method: %s; response status: %d",
+		request.ServerName,
+		request.Url,
+		request.Method,
+		request.StatusCode,
+	)
+}
+
 type Collector struct {
 	Chan     chan Request
 	requests map[Request]int
@@ -24,7 +35,6 @@ func (collector *Collector) Add(request Request) {
 		collector.requests = make(map[Request]int)
 	}
 	collector.requests[request]++
-	log.Printf("Added %s (%d)\n", request, collector.requests[request])
 }
 
 func (collector Collector) Get(request Request) int {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -1,6 +1,8 @@
 package statistics
 
 import (
+	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -40,4 +42,19 @@ func TestCollectionFromChannel(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, 1, collector.Get(request))
+}
+
+func TestStringifyRequest(t *testing.T) {
+	request := Request{
+		ServerName: "Simple server",
+		Url:        "/some_url",
+		Method:     "POST",
+		StatusCode: http.StatusCreated,
+	}
+
+	assert.Equal(
+		t,
+		"server: Simple server; url: /some_url; method: POST; response status: 201",
+		fmt.Sprintf("%s", request),
+	)
 }


### PR DESCRIPTION
Не знаю почему, но отправка реквеста в канал статистики вешала сервер. Сделал так, чтобы канал не создавался, когда не надо.